### PR TITLE
fix(cli): narrow AI-call exception handling to expected failure modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           cache: "pip"
 
       - name: Install Ruff
-        run: pip install ruff
+        run: pip install ruff==0.12.3
 
       - name: Ruff check
         run: ruff check .

--- a/git_explain/cli.py
+++ b/git_explain/cli.py
@@ -8,8 +8,11 @@ from pathlib import Path
 from collections.abc import Callable
 from typing import Iterable
 
+import httpx
+import requests
 import typer
 from dotenv import dotenv_values
+from google.genai import errors as genai_errors
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -39,6 +42,16 @@ _AI_ENV_KEYS = (
 )
 # Terminal hyperlinks (OSC 8) for first-run setup — Ctrl+click in supported terminals.
 _GOOGLE_AI_API_KEY_URL = "https://aistudio.google.com/apikey"
+
+# Expected failure modes from an AI call: missing key / unparseable response
+# (RuntimeError), Gemini API errors, and network-level failures. Anything else
+# is a real bug and should not be silently treated as "AI unavailable".
+_AI_CALL_ERRORS = (
+    RuntimeError,
+    genai_errors.APIError,
+    httpx.HTTPError,
+    requests.exceptions.RequestException,
+)
 
 
 def _gemini_fallback_notifier(
@@ -578,7 +591,7 @@ def run(
                 if sug is None:
                     raise RuntimeError("Could not parse AI suggestion.")
                 return sug, None
-            except Exception as e:
+            except _AI_CALL_ERRORS as e:
                 h = suggest_from_changes(
                     changes=change_items,
                     has_commits=has_commits,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
-    "ruff>=0.8.0",
+    "ruff==0.12.3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- `suggest_for()` in `cli.py` caught bare `Exception` around the AI call, so any bug in the AI path (not just network/API failures) was silently reported as "AI unavailable" and fell back to local heuristics.
- Narrowed the catch to `RuntimeError` (missing key / unparseable response), Gemini API errors (`genai_errors.APIError`), and network-level errors (`httpx.HTTPError`, `requests.exceptions.RequestException`).

## Test plan
- [x] `pytest -q`
- [x] `ruff check .` / `ruff format --check .`

Closes #16

(Re-opened as a new PR: the original PR #24 was auto-closed by GitHub when `main`'s history was rewritten to correct a contributor's commit attribution — this branch is unchanged.)